### PR TITLE
mondrian: fix param used in mi_dsi_panel_update_lhbm_white_param

### DIFF
--- a/msm/mi_disp/mi_dsi_panel.c
+++ b/msm/mi_disp/mi_dsi_panel.c
@@ -3151,8 +3151,7 @@ static int mi_dsi_panel_set_lhbm_fod_locked(struct dsi_panel *panel,
 				DSI_CMD_SET_MI_LOCAL_HBM_NORMAL_WHITE_1000NIT, update_bl);
 
 		mi_dsi_panel_update_lhbm_white_param(panel,
-				DSI_CMD_SET_MI_LOCAL_HBM_NORMAL_WHITE_1000NIT,
-				mi_cfg->feature_val[DISP_FEATURE_FLAT_MODE]);
+				DSI_CMD_SET_MI_LOCAL_HBM_NORMAL_WHITE_1000NIT, 1);
 		rc = dsi_panel_tx_cmd_set(panel, DSI_CMD_SET_MI_LOCAL_HBM_NORMAL_WHITE_1000NIT);
 		break;
 	case LOCAL_HBM_NORMAL_WHITE_750NIT:


### PR DESCRIPTION
Fix param used in mi_dsi_panel_update_lhbm_white_param

Fix screen darken issue when using fod.

After this, we need to change DISP_PARAM_LOCAL_HBM_ON back to 1 in udfps handler, which is done in  https://github.com/cupid-development/android_device_xiaomi_sm8450-common/pull/2
